### PR TITLE
Checking wget and unzip command firstly

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+if [ ! $(which wget) ]; then
+    echo 'Please install wget package'
+    exit 1
+fi
+
+if [ ! $(which unzip) ]; then
+    echo 'Please install zip package'
+    exit 1
+fi
+
 if (( $EUID != 0 )); then
     echo "Please run as root"
     exit 1


### PR DESCRIPTION
# Changed log
- Before executing `install.sh` Bash script, it should check `wget` and `unzip` packages are available.